### PR TITLE
Make item properties available via API

### DIFF
--- a/datasources/items.js
+++ b/datasources/items.js
@@ -1,3 +1,5 @@
+const { item } = require(".");
+
 class ItemsAPI {
     constructor(){
         this.cache = false;
@@ -10,7 +12,7 @@ class ItemsAPI {
             if(this.cache){
                 return true;
             }
-            this.loading = ITEM_DATA.get('ITEM_CACHE_V3', 'json');
+            this.loading = ITEM_DATA.get('ITEM_CACHE_V4', 'json');
             this.cache = await this.loading;
             this.loading = false;
         } catch (error){
@@ -138,6 +140,24 @@ class ItemsAPI {
         });
     }
 
+    async getItemsByTypes(types, items = false) {
+        await this.init();
+        let format = false;
+        if (!items) {
+            items = Object.values(this.cache.data);
+            format = true;
+        }
+        return items.filter((rawItem) => {
+            for (const type of types) {
+                if (rawItem.types.includes(type) || type === 'any') return true;
+            }
+            return false;
+        }).map((rawItem) => {
+            if (!format) return rawItem;
+            return this.formatItem(rawItem);
+        });
+    }
+
     async getItemsByName(name, items = false, lang = 'en') {
         await this.init();
         let format = false;
@@ -182,7 +202,6 @@ class ItemsAPI {
                 if (rawItem.locale[lang].shortName && rawItem.locale[lang].shortName.toString().toLowerCase().includes(search)) {
                     return true;
                 }
-                return false;
             }
             return false;
         }).map((rawItem) => {
@@ -288,6 +307,11 @@ class ItemsAPI {
     async getFleaMarket() {
         await this.init();
         return this.cache.flea;
+    }
+
+    async getArmorMaterial(matKey) {
+        await this.init();
+        return this.cache.armorMats[matKey];
     }
 }
 

--- a/datasources/items.js
+++ b/datasources/items.js
@@ -358,6 +358,11 @@ class ItemsAPI {
         return this.cache.flea;
     }
 
+    async getArmorMaterials() {
+        await this.init();
+        return Object.values(this.cache.armorMats).sort();
+    }
+
     async getArmorMaterial(matKey) {
         await this.init();
         return this.cache.armorMats[matKey];

--- a/datasources/tasks.js
+++ b/datasources/tasks.js
@@ -29,7 +29,7 @@ class TasksAPI {
     async get(id) {
         await this.init();
         for (const task of this.cache.data) {
-            if (task.id === id || task.tarkovDataId) return task;
+            if (task.id === id || task.tarkovDataId === id) return task;
         }
         return Promise.reject(new Error(`No task found with id ${id}`));
     }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const crypto = require('crypto');
 const { makeExecutableSchema } = require('@graphql-tools/schema');
+const { mergeTypeDefs } = require('@graphql-tools/merge');
 
 const {
     graphql,
@@ -10,6 +11,7 @@ const dataAPI = require('./datasources');
 const playground = require('./handlers/playground');
 const setCors = require('./utils/setCors');
 const typeDefs = require('./schema');
+const dynamicTypeDefs = require('./schema_dynamic');
 const resolvers = require('./resolvers');
 const graphqlUtil = require('./utils/graphql-util');
 
@@ -17,9 +19,6 @@ require('./loader');
 
 const nightbot = require('./custom-endpoints/nightbot');
 const twitch = require('./custom-endpoints/twitch');
-
-//const schema = buildSchema(typeDefs);
-const schema = makeExecutableSchema({typeDefs, resolvers: resolvers});
 
 /**
  * Example of how router can be used in an application
@@ -74,6 +73,8 @@ async function graphqlHandler(request, graphQLOptions) {
     //await resolvers.itemInit();
     //await dataAPI.init();
 
+    //const schema = buildSchema(typeDefs);
+    const schema = makeExecutableSchema({typeDefs: mergeTypeDefs([typeDefs, await dynamicTypeDefs(dataAPI)]), resolvers: resolvers});
     const result = await graphql(schema, query, {}, {data: dataAPI, util: graphqlUtil}, variables);
     const body = JSON.stringify(result);
 

--- a/resolvers/itemResolver.js
+++ b/resolvers/itemResolver.js
@@ -24,8 +24,14 @@ module.exports = {
                 types: async types => {
                     return context.data.item.getItemsByTypes(types, items);
                 },
+                categoryNames: async bsgcats => {
+                    return context.data.item.getItemsByCategoryEnums(bsgcats, items);
+                },
                 bsgCategoryId: async bsgcat => {
                     return context.data.item.getItemsByBsgCategoryId(bsgcat, items);
+                },
+                bsgCategoryIds: async bsgcats => {
+                    return context.data.item.getItemsByBsgCategoryIds(bsgcats, items);
                 },
                 bsgCategory: async bsgcat => {
                     return context.data.item.getItemsInBsgCategory(bsgcat, items);
@@ -178,6 +184,30 @@ module.exports = {
     ItemPropertiesArmor: {
         material(data, args, context) {
             return context.data.item.getArmorMaterial(data.armor_material_id);
+        },
+        zones(data, args, context, info) {
+            return context.util.getLocale(data, 'zones', info);
+        }
+    },
+    ItemPropertiesChestRig: {
+        material(data, args, context) {
+            return context.data.item.getArmorMaterial(data.armor_material_id);
+        },
+        zones(data, args, context, info) {
+            return context.util.getLocale(data, 'zones', info);
+        }
+    },
+    ItemPropertiesHelmet: {
+        material(data, args, context) {
+            return context.data.item.getArmorMaterial(data.armor_material_id);
+        },
+        headZones(data, args, context, info) {
+            return context.util.getLocale(data, 'headZones', info);
+        }
+    },
+    ItemPropertiesWeapon: {
+        defaultAmmo(data, args, context) {
+            return context.data.item.getItem(data.default_ammo_id);
         },
     },
     ContainedItem: {

--- a/resolvers/itemResolver.js
+++ b/resolvers/itemResolver.js
@@ -70,6 +70,9 @@ module.exports = {
         historicalItemPrices(obj, args, context, info) {
             return context.data.historicalPrice.getByItemId(args.id);
         },
+        armorMaterials(obj, args, context) {
+            return context.data.item.getArmorMaterials();
+        },
         fleaMarket(obj, args, context) {
             return context.data.item.getFleaMarket();
         }
@@ -225,8 +228,8 @@ module.exports = {
         }
     },
     FleaMarket: {
-        name(data) {
-            return 'Flea Market';
+        name(data, args, context, info) {
+            return context.util.getLocale(data, 'name', info);
         }
     },
     RequirementItem: {

--- a/resolvers/itemResolver.js
+++ b/resolvers/itemResolver.js
@@ -21,6 +21,9 @@ module.exports = {
                 type: async type => {
                     return context.data.item.getItemsByType(type, items);
                 },
+                types: async types => {
+                    return context.data.item.getItemsByTypes(types, items);
+                },
                 bsgCategoryId: async bsgcat => {
                     return context.data.item.getItemsByBsgCategoryId(bsgcat, items);
                 },
@@ -166,6 +169,17 @@ module.exports = {
             return context.data.item.getItem(data.currencyItem);
         }
     },
+    ItemProperties: {
+        __resolveType(data) {
+            if (data.propertiesType) return data.propertiesType;
+            return null;
+        }
+    },
+    ItemPropertiesArmor: {
+        material(data, args, context) {
+            return context.data.item.getArmorMaterial(data.armor_material_id);
+        },
+    },
     ContainedItem: {
         item(data, args, context) {
             if (data.contains) return context.data.item.getItem(data.item, data.contains);
@@ -173,6 +187,11 @@ module.exports = {
         },
         quantity(data, args, context) {
             return data.count;
+        }
+    },
+    ArmorMaterial: {
+        name(data, args, context, info) {
+            return context.util.getLocale(data, 'name', info);
         }
     },
     FleaMarket: {

--- a/schema.js
+++ b/schema.js
@@ -45,6 +45,7 @@ type Ammo {
 #}
 
 type ArmorMaterial {
+  id: String
   name: String
   destructibility: Float
   minRepairDegradation: Float
@@ -823,17 +824,18 @@ type Query {
   ammo(lang: LanguageCode): [Ammo]  
   barters(lang: LanguageCode): [Barter]
   crafts(lang: LanguageCode): [Craft]
-  fleaMarket(lang: LanguageCode): FleaMarket!
   hideoutStations(lang: LanguageCode): [HideoutStation]!
   historicalItemPrices(id: ID!, lang: LanguageCode): [historicalPricePoint]!
   item(id: ID, normalizedName: String, lang: LanguageCode): Item
   items(ids: [ID], name: String, names: [String], type: ItemType, types: [ItemType], categoryNames: [ItemCategoryName], bsgCategoryId: String, bsgCategoryIds: [String], bsgCategory: String, lang: LanguageCode): [Item]!
-  itemCategories: [ItemCategory]!
+  itemCategories(lang: LanguageCode): [ItemCategory]!
   maps(lang: LanguageCode): [Map]!
   status: ServerStatus!
   task(id: ID!, lang: LanguageCode): Task
   tasks(faction: String, lang: LanguageCode): [Task]!
   traders(lang: LanguageCode): [Trader]!
+  fleaMarket(lang: LanguageCode): FleaMarket!
+  armorMaterials(lang: LanguageCode): [ArmorMaterial]!
   hideoutModules: [HideoutModule] @deprecated(reason: "Use hideoutStations instead.")
   itemsByIDs(ids: [ID]!): [Item] @deprecated(reason: "Use items instead.")
   itemsByType(type: ItemType!): [Item]! @deprecated(reason: "Use items instead.")

--- a/schema.js
+++ b/schema.js
@@ -256,6 +256,30 @@ type ItemPropertiesArmor {
   material: ArmorMaterial
 }
 
+type ItemPropertiesArmorAttachment {
+  class: Int
+  durability: Int
+  repairCost: Int
+  speedPenalty: Float
+  turnPenalty: Float
+  ergoPenalty: Int
+  headZones: [String]
+  material: ArmorMaterial
+}
+
+type ItemPropertiesChestRig {
+  class: Int
+  durability: Int
+  repairCost: Int
+  speedPenalty: Float
+  turnPenalty: Float
+  ergoPenalty: Int
+  zones: [String]
+  material: ArmorMaterial
+  capacity: Int
+  pouches: [ItemStorageGrid]
+}
+
 type ItemPropertiesFoodDrink {
   energy: Int
   hydration: Int
@@ -271,20 +295,103 @@ type ItemPropertiesGrenade {
   contusionRadius: Int
 }
 
-type ItemPropertiesTacticalRig {
+type ItemPropertiesHelmet {
   class: Int
   durability: Int
   repairCost: Int
   speedPenalty: Float
   turnPenalty: Float
   ergoPenalty: Int
-  zones: [String]
+  headZones: [String]
   material: ArmorMaterial
-  capacity: Int
-  pouches: [ItemStorageGrid]
+  deafening: String
 }
 
-union ItemProperties = ItemPropertiesAmmo | ItemPropertiesArmor | ItemPropertiesFoodDrink | ItemPropertiesGrenade | ItemPropertiesTacticalRig
+type ItemPropertiesMagazine {
+  ergonomics: Float
+  recoil: Float
+  capacity: Int
+  loadModifier: Float
+  ammoCheckModifier: Float
+  malfunctionChance: Float
+}
+
+type ItemPropertiesMedicalItem {
+  uses: Int
+  useTime: Int
+  cures: [String]
+}
+
+type ItemPropertiesMedKit {
+  hitpoints: Int
+  useTime: Int
+  maxHealPerUse: Int
+  cures: [String]
+  hpCostLightBleeding: Int
+  hpCostHeavyBleeding: Int
+}
+
+type ItemPropertiesNightVision {
+  intensity: Float
+  noiseIntensity: Float
+  noiseScale: Float
+  diffuseIntensity: Float
+}
+
+type ItemPropertiesPainkiller {
+  uses: Int
+  useTime: Int
+  cures: [String]
+  painkillerDuration: Int
+  energyImpact: Int
+  hydrationImpact: Int
+}
+
+type ItemPropertiesScope {
+  ergonomics: Float
+  recoil: Float
+  zoomLevels: [[Float]]
+}
+
+type ItemPropertiesSurgicalKit {
+  uses: Int
+  useTime: Int
+  cures: [String]
+  minLimbHealth: Float
+  maxLimbHealth: Float
+}
+
+type ItemPropertiesWeapon {
+  caliber: String
+  ergonomics: Float
+  recoilVertical: Int
+  recoilHorizontal: Int
+  repairCost: Int
+  defaultAmmo: Item
+}
+
+type ItemPropertiesWeaponMod {
+  ergonomics: Float
+  recoil: Float
+}
+
+union ItemProperties = 
+  ItemPropertiesAmmo | 
+  ItemPropertiesArmor | 
+  ItemPropertiesArmorAttachment | 
+  ItemPropertiesChestRig | 
+  ItemPropertiesFoodDrink | 
+  ItemPropertiesGrenade | 
+  ItemPropertiesHelmet | 
+  ItemPropertiesMagazine | 
+  ItemPropertiesMedicalItem | 
+  ItemPropertiesMedKit | 
+  ItemPropertiesNightVision | 
+  ItemPropertiesPainkiller | 
+  ItemPropertiesScope | 
+  ItemPropertiesSurgicalKit | 
+  ItemPropertiesWeapon | 
+  ItemPropertiesWeaponMod
 
 enum ItemSourceName {
   prapor
@@ -720,7 +827,7 @@ type Query {
   hideoutStations(lang: LanguageCode): [HideoutStation]!
   historicalItemPrices(id: ID!, lang: LanguageCode): [historicalPricePoint]!
   item(id: ID, normalizedName: String, lang: LanguageCode): Item
-  items(ids: [ID], name: String, names: [String], type: ItemType, types: [ItemType], bsgCategoryId: String, bsgCategory: String, lang: LanguageCode): [Item]!
+  items(ids: [ID], name: String, names: [String], type: ItemType, types: [ItemType], categoryNames: [ItemCategoryName], bsgCategoryId: String, bsgCategoryIds: [String], bsgCategory: String, lang: LanguageCode): [Item]!
   itemCategories: [ItemCategory]!
   maps(lang: LanguageCode): [Map]!
   status: ServerStatus!

--- a/schema.js
+++ b/schema.js
@@ -44,6 +44,16 @@ type Ammo {
 #  value: Int!
 #}
 
+type ArmorMaterial {
+  name: String
+  destructibility: Float
+  minRepairDegradation: Float
+  maxRepairDegradation: Float
+  explosionDestructibility: Float
+  minRepairKitDegradation: Float
+  maxRepairKitDegradation: Float
+}
+
 type AttributeThreshold {
   name: String!
   requirement: NumberCompare!
@@ -155,6 +165,7 @@ type Item {
   gridImageLinkFallback: String!
   types: [ItemType]!
   avg24hPrice: Int
+  properties: ItemProperties
   accuracyModifier: Float
   recoilModifier: Float
   ergonomicsModifier: Float
@@ -214,6 +225,67 @@ type ItemPrice {
   requirements: [PriceRequirement]! @deprecated(reason: "Use vendor instead.")
 }
 
+type ItemPropertiesAmmo {
+  caliber: String!
+  stackMaxSize: Int!
+  tracer: Boolean!
+  tracerColor: String
+  ammoType: String!
+  projectileCount: Int
+  damage: Int!
+  armorDamage: Int!
+  fragmentationChance: Float!
+  ricochetChance: Float!
+  penetrationChance: Float!
+  penetrationPower: Int!
+  accuracy: Int!
+  recoil: Int!
+  initialSpeed: Int!
+  lightBleedModifier: Float!
+  heavyBleedModifier: Float!
+}
+
+type ItemPropertiesArmor {
+  class: Int
+  durability: Int
+  repairCost: Int
+  speedPenalty: Float
+  turnPenalty: Float
+  ergoPenalty: Int
+  zones: [String]
+  material: ArmorMaterial
+}
+
+type ItemPropertiesFoodDrink {
+  energy: Int
+  hydration: Int
+  units: Int
+}
+
+type ItemPropertiesGrenade {
+  type: String
+  fuse: Float
+  minExplosionDistance: Int
+  maxExplosionDistance: Int
+  fragments: Int
+  contusionRadius: Int
+}
+
+type ItemPropertiesTacticalRig {
+  class: Int
+  durability: Int
+  repairCost: Int
+  speedPenalty: Float
+  turnPenalty: Float
+  ergoPenalty: Int
+  zones: [String]
+  material: ArmorMaterial
+  capacity: Int
+  pouches: [ItemStorageGrid]
+}
+
+union ItemProperties = ItemPropertiesAmmo | ItemPropertiesArmor | ItemPropertiesFoodDrink | ItemPropertiesGrenade | ItemPropertiesTacticalRig
+
 enum ItemSourceName {
   prapor
   therapist
@@ -224,6 +296,11 @@ enum ItemSourceName {
   ragman
   jaeger
   fleaMarket
+}
+
+type ItemStorageGrid {
+  width: Int!
+  height: Int!
 }
 
 enum ItemType {
@@ -643,7 +720,7 @@ type Query {
   hideoutStations(lang: LanguageCode): [HideoutStation]!
   historicalItemPrices(id: ID!, lang: LanguageCode): [historicalPricePoint]!
   item(id: ID, normalizedName: String, lang: LanguageCode): Item
-  items(ids: [ID], name: String, names: [String], type: ItemType, bsgCategoryId: String, bsgCategory: String, lang: LanguageCode): [Item]!
+  items(ids: [ID], name: String, names: [String], type: ItemType, types: [ItemType], bsgCategoryId: String, bsgCategory: String, lang: LanguageCode): [Item]!
   itemCategories: [ItemCategory]!
   maps(lang: LanguageCode): [Map]!
   status: ServerStatus!

--- a/schema_dynamic.js
+++ b/schema_dynamic.js
@@ -1,0 +1,9 @@
+module.exports = async (data) => {
+    const categories = await data.item.getCategories();
+    let categoryEnum = `
+enum ItemCategoryName {
+  ${categories.map(cat => cat.enumName).sort().join('\n  ')}
+}
+    `;
+    return categoryEnum;
+};

--- a/utils/graphql-util.js
+++ b/utils/graphql-util.js
@@ -29,7 +29,7 @@ module.exports = {
     },
     getLocale: (data, field, info) => {
         const lang = module.exports.getLang(info);
-        if (data.locale && data.locale[lang] && data.locale[lang][field]) return data.locale[lang][field];
+        if (data.locale && lang in data.locale && field in data.locale[lang]) return data.locale[lang][field];
         return data[field];
     }
 };


### PR DESCRIPTION
So far, the properties attribute of the Item type can display relevant properties for:

- ammo
- armor vests
- chest rigs
- grenades
- food / drinks
- armored equipment attachments (e.g., face shields, etc)
- weapons
- weapon attachments
- meds

Example query:
`query {
  items(names: ["ration", "water", "vodka", "plate", "M855"]) {
    id
    name
    bsgCategoryId
    properties {
      ... on ItemPropertiesArmor {
        material {
          name
        }
        class
        speedPenalty
        ergoPenalty
      }
      ...on ItemPropertiesTacticalRig {
        capacity
        class
        pouches {
          width
          height
        }
      }
      ...on ItemPropertiesAmmo {
        penetrationPower
        damage
        armorDamage
      }
      ... on ItemPropertiesGrenade {
        type
        fuse
        minExplosionDistance
        maxExplosionDistance
        fragments
        contusionRadius
      }
      ...on ItemPropertiesFoodDrink {
        energy
        hydration
        units
      }
    }
  }
}`