### PR TITLE
bump to v1.4.2

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
 
-      - uses: GrantBirki/branch-deploy@8290f4d0376d06d0ecd74c05363bc045e7e6950a # pin@v1.4.1
+      - uses: GrantBirki/branch-deploy@5d7ea46552d858242fa4bf16625e9f29b1ee1b63 # pin@v1.4.2
         id: branch-deploy
 
       - name: Checkout


### PR DESCRIPTION
# Bump `branch-deploy` Action to v1.4.2

This PR updates the `branch-deploy` Action to use the latest version which includes one minor bug fix